### PR TITLE
Revert "fix: csr -> instinfo in BiInstQueue"

### DIFF
--- a/src/src/pipeline/queue/BiInstQueue.scala
+++ b/src/src/pipeline/queue/BiInstQueue.scala
@@ -190,10 +190,7 @@ class BiInstQueue(
       dequeuePort.bits.instInfo
         .exceptionRecords(Csr.ExceptionIndex.ine) := !isMatched
       dequeuePort.bits.instInfo.isValid := decodeInstInfo.pcAddr.orR // TODO: Check if it can change to isMatched (see whether commit or not)
-      dequeuePort.bits.instInfo.csrWritePort.en := selectedDecoder.info.csrWriteEn
-      dequeuePort.bits.instInfo.csrWritePort.addr := selectedDecoder.info.csrAddr
-    }
-
+  }
 
   when(io.isFlush) {
     ram.foreach(_ := InstInfoBundle.default)


### PR DESCRIPTION
Reverts Invalid-Syntax-NSCSCC/invalid-cpu#99

This change cannot pass test.